### PR TITLE
Use style id to link styles with document elements (fixes #1785)

### DIFF
--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -64,9 +64,10 @@ class Styles extends AbstractPart
         if ($nodes->length > 0) {
             foreach ($nodes as $node) {
                 $type = $xmlReader->getAttribute('w:type', $node);
+                $id = $xmlReader->getAttribute('w:styleId', $node);
                 $name = $xmlReader->getAttribute('w:val', $node, 'w:name');
                 if (is_null($name)) {
-                    $name = $xmlReader->getAttribute('w:styleId', $node);
+                    $name = $id;
                 }
                 $headingMatches = array();
                 preg_match('/Heading\s*(\d)/i', $name, $headingMatches);
@@ -80,9 +81,11 @@ class Styles extends AbstractPart
                         } else {
                             if (empty($fontStyle)) {
                                 if (is_array($paragraphStyle)) {
+                                    $phpWord->addParagraphStyle($id, $paragraphStyle);
                                     $phpWord->addParagraphStyle($name, $paragraphStyle);
                                 }
                             } else {
+                                $phpWord->addFontStyle($id, $fontStyle, $paragraphStyle);
                                 $phpWord->addFontStyle($name, $fontStyle, $paragraphStyle);
                             }
                         }
@@ -90,12 +93,14 @@ class Styles extends AbstractPart
                     case 'character':
                         $fontStyle = $this->readFontStyle($xmlReader, $node);
                         if (!empty($fontStyle)) {
+                            $phpWord->addFontStyle($id, $fontStyle);
                             $phpWord->addFontStyle($name, $fontStyle);
                         }
                         break;
                     case 'table':
                         $tStyle = $this->readTableStyle($xmlReader, $node);
                         if (!empty($tStyle)) {
+                            $phpWord->addTableStyle($id, $tStyle);
                             $phpWord->addTableStyle($name, $tStyle);
                         }
                         break;

--- a/tests/PhpWord/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWord/Reader/Word2007/StyleTest.php
@@ -226,4 +226,23 @@ class StyleTest extends AbstractTestReader
         $sectionStyle = $phpWord->getSection(0)->getStyle();
         $this->assertEquals(VerticalJc::CENTER, $sectionStyle->getVAlign());
     }
+
+    public function testGetStyleByStyleId()
+    {
+        $styleXml = '<w:style w:styleId="StyleId" w:type="character">
+            <w:name w:val="StyleName"/>
+            <w:qFormat/>
+            <w:rPr>
+                <w:b/>
+                <w:bCs/>
+            </w:rPr>
+        </w:style>';
+
+        $styleId = 'StyleId';
+        $name = 'StyleName';
+
+        $this->getDocumentFromString(array('styles' => $styleXml));
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', Style::getStyle($styleId));
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', Style::getStyle($name));
+    }
 }


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
